### PR TITLE
update: Screening Assessment

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,11 +1,37 @@
 import LeftNavigationMenu from "./LeftNavigationMenu";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { screen } from "@testing-library/react";
 import Header from "./Header";
 import "../public/css/components/Layout.css";
+import { useLocation } from "react-router-dom";
+
 
 const Layout = ({ children }) => {
   const [isLeftNavigationOpen, setIsLeftNavigationOpen] = useState(true);
+  const location = useLocation()
+
+  // Catch browser refresh and back button: 
+  // we do not need the dependency array
+  useEffect(() => {
+    const inProgress = localStorage.getItem('inProgress')
+
+    window.onpopstate = (ev) => {
+      // Remove the backdrop of the modal if the user
+      // navigates away from the screening page without
+      // starting the assessment. Otherwise, the dialogBox.js
+      // handles the removal of the modal backdrop.
+      if (!inProgress) {
+        document.querySelector('.modal-backdrop')?.remove()
+      }
+    }
+
+    if (inProgress && location.pathname === '/screening') {
+      window.onbeforeunload = () => { return true }
+    } else {
+      window.onbeforeunload = null
+      localStorage.removeItem('inProgress')
+    }
+  })
 
   const handleLeftNavigation = () => {
     const sideMenu = document.getElementById("side-menu");

--- a/src/components/screening/dialogBox.js
+++ b/src/components/screening/dialogBox.js
@@ -1,0 +1,24 @@
+const DialogBox = ({ showDialog, cancelNavigation, confirmNavigation, }) => {
+    return (
+        <>
+            <div className={`${showDialog ? 'modal fade show d-block' : 'modal fade'}`} style={{ 'zIndex': '10000' }}>
+                <div className="modal-dialog shadow-lg">
+                    <div className="modal-content">
+                        <div className="modal-header bg-primary">
+                            <h5 className="modal-title text-white">Leave Page?</h5>
+                        </div>
+                        <div className="modal-body">
+                            <p className="mb-0">You haven't finished the screening assessment yet. Do you want to leave without finishing?</p>
+                        </div>
+                        <div className="modal-footer">
+                            <button type="button" className="btn btn-light" onClick={cancelNavigation}>Stay on Page</button>
+                            <button type="button" className="btn btn-danger" onClick={confirmNavigation}>Leave Page</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default DialogBox;

--- a/src/components/screening/screeningWizard.js
+++ b/src/components/screening/screeningWizard.js
@@ -15,7 +15,7 @@ const ScreeningWizard = () => {
     const [totalAnswered, setTotalAnswered] = useState(0)
     const [shouldEnableSubmit, setShouldEnableSubmit] = useState(false)
     const [sections, setSections] = useState({})
-    const {answers, setAnswers, patientSelected, dateStarted} = useContext(AnswerContext)
+    const {answers, setAnswers, patientSelected, dateStarted, setShowDialog} = useContext(AnswerContext)
     const { user } = useContext(AuthContext)
     const [classification, setClassification] = useState(null)
     const [classProbability, setClassProbability] = useState(null)
@@ -91,6 +91,10 @@ const ScreeningWizard = () => {
     }
 
     const handleReturn = () => {
+        setShowDialog(false)
+        localStorage.removeItem('inProgress')
+        window.onbeforeunload = null
+        
         setTimeout(() => {
             setMustShowResult(false)
             setShouldEnableSubmit(false)

--- a/src/lib/useBlocker.js
+++ b/src/lib/useBlocker.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { UNSAFE_NavigationContext } from 'react-router-dom';
+
+// https://dev.to/bangash1996/detecting-user-leaving-page-with-react-router-dom-v602-33ni
+export function useBlocker(blocker, when = true) {
+    const navigator = React.useContext(UNSAFE_NavigationContext)
+        .navigator;
+
+    React.useEffect(() => {
+        if (!when) return;
+
+        const unblock = navigator.block((tx) => {
+            const autoUnblockingTx = {
+                ...tx,
+                retry() {
+                    unblock();
+                    tx.retry();
+                },
+            };
+
+            blocker(autoUnblockingTx);
+        });
+
+        return unblock;
+    }, [navigator, blocker, when]);
+}

--- a/src/lib/useCallbackPrompt.js
+++ b/src/lib/useCallbackPrompt.js
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+import { useBlocker } from './useBlocker'
+
+// https://dev.to/bangash1996/detecting-user-leaving-page-with-react-router-dom-v602-33ni
+export function useCallbackPrompt(when ) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [showPrompt, setShowPrompt] = useState(false)
+  const [lastLocation, setLastLocation] = useState(null)
+  const [confirmedNavigation, setConfirmedNavigation] = useState(false)
+
+  const cancelNavigation = useCallback(() => {
+    setShowPrompt(false)
+    setLastLocation(null)
+  }, [])
+
+  // handle blocking when user click on another route prompt will be shown
+  const handleBlockedNavigation = useCallback((nextLocation) => {
+      // in if condition we are checking next location and current location are equals or not
+      if (!confirmedNavigation && nextLocation.location.pathname !== location.pathname) {
+        setShowPrompt(true)
+        setLastLocation(nextLocation)
+        return false
+      }
+      return true
+    },
+    [confirmedNavigation, location]
+  )
+
+  const confirmNavigation = useCallback(() => {
+    setShowPrompt(false)
+    setConfirmedNavigation(true)
+  }, [])
+
+  useEffect(() => {
+    if (confirmedNavigation && lastLocation) {
+      // Remove the backdrop of the modal
+      document.querySelector('.modal-backdrop')?.classList.remove('fade')
+      document.querySelector('.modal-backdrop')?.classList.remove('show')
+      document.querySelector('.modal-backdrop')?.remove()
+
+      navigate(lastLocation.location?.pathname)
+
+      // Clean-up state on confirmed navigation
+      setConfirmedNavigation(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confirmedNavigation, lastLocation])
+
+  useBlocker(handleBlockedNavigation, when)
+
+  return [showPrompt, confirmNavigation, cancelNavigation]
+}

--- a/src/pages/screeningPage.js
+++ b/src/pages/screeningPage.js
@@ -9,9 +9,19 @@ import Api from '../services/api'
 import Pagination from '../components/customPagination/Pagination'
 import { useRef } from 'react'
 import AuthContext from '../auth/AuthContext'
+import { useCallbackPrompt } from '../lib/useCallbackPrompt'
+import DialogBox from '../components/screening/dialogBox'
 
 
 const ScreeningPage = () => {
+
+    const [showDialog, setShowDialog] = useState(false)
+    const [showPrompt, confirmNavigation, cancelNavigation] = useCallbackPrompt(showDialog)
+    useEffect(() => {
+        // Used to reset inProgress if the user opts
+        //  to cancel the assessment
+        localStorage.removeItem('inProgress')
+    }, [])
 
     const { user } = useContext(AuthContext)
     const searchQuery = useRef(null)
@@ -67,6 +77,11 @@ const ScreeningPage = () => {
     }
 
     const handleProceed = () => {
+        // Shows a warning dialog if a user leaves the page
+        setShowDialog(true)
+        localStorage.setItem('inProgress', true)
+        window.onbeforeunload = () => { return true }
+
         // When proceed is clicked, take note of when the screening started
         // This is to be used to get time elapsed for the total screening duration
         const date = new Date().toLocaleString('en-ZA', { hour12: false }).replaceAll('/', '-').replace(',', '')
@@ -180,10 +195,12 @@ const ScreeningPage = () => {
     }, [nameQuery, allSearchedPatients, allPatients, total, currentPage, user]);
 
 
-
     return (
         <Layout>
-            <AnswerContext.Provider value={{ answers, setAnswers, patientSelected, dateStarted }}>
+            <AnswerContext.Provider value={{ answers, setAnswers, patientSelected, dateStarted, setShowDialog }}>
+
+                <DialogBox showDialog={showPrompt} confirmNavigation={confirmNavigation} cancelNavigation={cancelNavigation}></DialogBox>
+
                 <div className='d-flex flex-column h-100 '>
                     <div className="container mt-2">
                         <div className="vh-75 d-flex flex-column align-items-center justify-content-center">
@@ -207,7 +224,7 @@ const ScreeningPage = () => {
                 <ScreeningWizard />
 
 
-                <div className="modal fade" id="select-a-patient" tabIndex="-1" aria-labelledby="select-a-patient-modal-title" aria-hidden="true">
+                <div className="modal fade" id="select-a-patient" tabIndex="-1" aria-labelledby="select-a-patient-modal-title" aria-hidden="true" data-bs-keyboard="true">
                     <div className="modal-dialog  modal-dialog-centered modal-dialog-scrollable modal-lg">
                         <div className="modal-content border-0">
                             <div className="modal-header bg-primary">


### PR DESCRIPTION
- added custom hook: useCallbackPrompt and useBlocker to block navigation context for browser back event
- added a custom dialog box to be shown if the user navigates away from the screening assessment page
- Added setShowDialog function inside screeningWizard to set the dialog to false so that the user can now navigate after the screening is complete
- Added window.onbeforeunload event inside Layout, screeningWizard's handleReturn to catch page reload/refresh
- Added localStorage for inProgress to indicate that the screening assessment has started: to be used to catch refresh/reload event (needed a local storage because the event is caught inside Layout.js) It is handled by Layout.js because it is the parent component of all the other pages.